### PR TITLE
Add ptysnoop.ply to scripts

### DIFF
--- a/scripts/ptysnoop.ply
+++ b/scripts/ptysnoop.ply
@@ -1,0 +1,11 @@
+#!/usr/bin/env ply
+
+kprobe:pty_write / strcmp("ply", comm()) /
+{
+  if (arg(2) == 1) {
+    printf("%s: %02x\n", execname(), mem(arg(1), "B") & 0xff);
+  }
+  if (arg(2) == 2) {
+    printf("%s: %02x%02x\n", execname(), mem(arg(1), "B") & 0xff, (mem(arg(1), "H") >> 8) & 0xff);
+  }
+}


### PR DESCRIPTION
Snoops asci-codes of keypresses by probing pty_write()

Example of script to extract ascii from bash below.

The trap line catches sigint and sends it on to ply without
killing the script when user presses Ctrl-c.

trap "killall -SIGINT ply" INT
sudo ply ptysnoop.ply > keys.txt
cat keys.txt | grep bash: | awk '/bash: / { printf("%s", $2); next } 1' > hex.txt
xxd -r -p hex.txt