### PR TITLE
.gitignore: modified to properly filter out libtool binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ Makefile.in
 /configure
 /depcomp
 /install-sh
-/libtool
+/*libtool
 /ltmain.sh
 /m4
 /missing


### PR DESCRIPTION
I'm going to be completely honest, I don't know how your build system works, but I cross-compiled it using ./configure --host ... --build ... and produced (in my case obviously) x86_64-redhat-linux-libtool, which slipped through the .gitignore. This commit fixes that with /*libtool in .gitignore.

The above title and description is that of the single commit this pull request contains. I know it's a small thing, but I saw the issue in my own copy of the repo and I thought, why not, seems like something they wouldn't object to. Plus, it gives me something to waste time with at work :)